### PR TITLE
Add category and greeting support to chatbot

### DIFF
--- a/Kick ChatBOT/Form1.Designer.cs
+++ b/Kick ChatBOT/Form1.Designer.cs
@@ -40,6 +40,10 @@
             this.btnLoadConfig = new MetroFramework.Controls.MetroButton();
             this.toggleProxy = new MetroFramework.Controls.MetroToggle();
             this.lblProxy = new MetroFramework.Controls.MetroLabel();
+            this.txtManualMessage = new MetroFramework.Controls.MetroTextBox();
+            this.btnSendManual = new MetroFramework.Controls.MetroButton();
+            this.btnLoadCategoryMessages = new MetroFramework.Controls.MetroButton();
+            this.btnLoadGreetings = new MetroFramework.Controls.MetroButton();
             this.SuspendLayout();
             // 
             // metroButton1
@@ -195,12 +199,80 @@
             this.lblProxy.TabIndex = 20;
             this.lblProxy.Text = "Usar Proxies";
             this.lblProxy.Theme = MetroFramework.MetroThemeStyle.Dark;
+            //
+            // txtManualMessage
+            //
+            this.txtManualMessage.CustomButton.Image = null;
+            this.txtManualMessage.CustomButton.Location = new System.Drawing.Point(231, 1);
+            this.txtManualMessage.CustomButton.Name = "";
+            this.txtManualMessage.CustomButton.Size = new System.Drawing.Size(21, 21);
+            this.txtManualMessage.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
+            this.txtManualMessage.CustomButton.TabIndex = 1;
+            this.txtManualMessage.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
+            this.txtManualMessage.CustomButton.UseSelectable = true;
+            this.txtManualMessage.CustomButton.Visible = false;
+            this.txtManualMessage.Lines = new string[0];
+            this.txtManualMessage.Location = new System.Drawing.Point(23, 52);
+            this.txtManualMessage.MaxLength = 32767;
+            this.txtManualMessage.Name = "txtManualMessage";
+            this.txtManualMessage.PasswordChar = '\0';
+            this.txtManualMessage.PromptText = "Mensaje manual";
+            this.txtManualMessage.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.txtManualMessage.SelectedText = "";
+            this.txtManualMessage.SelectionLength = 0;
+            this.txtManualMessage.SelectionStart = 0;
+            this.txtManualMessage.ShortcutsEnabled = true;
+            this.txtManualMessage.Size = new System.Drawing.Size(253, 23);
+            this.txtManualMessage.Style = MetroFramework.MetroColorStyle.Green;
+            this.txtManualMessage.TabIndex = 21;
+            this.txtManualMessage.Theme = MetroFramework.MetroThemeStyle.Dark;
+            this.txtManualMessage.UseSelectable = true;
+            this.txtManualMessage.WaterMark = "Mensaje manual";
+            this.txtManualMessage.WaterMarkColor = System.Drawing.Color.FromArgb(((int)(((byte)(109)))), ((int)(((byte)(109)))), ((int)(((byte)(109)))));
+            this.txtManualMessage.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
+            //
+            // btnSendManual
+            //
+            this.btnSendManual.Location = new System.Drawing.Point(300, 52);
+            this.btnSendManual.Name = "btnSendManual";
+            this.btnSendManual.Size = new System.Drawing.Size(129, 23);
+            this.btnSendManual.Style = MetroFramework.MetroColorStyle.Teal;
+            this.btnSendManual.TabIndex = 22;
+            this.btnSendManual.Text = "Enviar manual";
+            this.btnSendManual.Theme = MetroFramework.MetroThemeStyle.Dark;
+            this.btnSendManual.UseSelectable = true;
+            //
+            // btnLoadCategoryMessages
+            //
+            this.btnLoadCategoryMessages.Location = new System.Drawing.Point(23, 155);
+            this.btnLoadCategoryMessages.Name = "btnLoadCategoryMessages";
+            this.btnLoadCategoryMessages.Size = new System.Drawing.Size(183, 23);
+            this.btnLoadCategoryMessages.Style = MetroFramework.MetroColorStyle.Blue;
+            this.btnLoadCategoryMessages.TabIndex = 23;
+            this.btnLoadCategoryMessages.Text = "Cargar category_messages.json";
+            this.btnLoadCategoryMessages.Theme = MetroFramework.MetroThemeStyle.Dark;
+            this.btnLoadCategoryMessages.UseSelectable = true;
+            //
+            // btnLoadGreetings
+            //
+            this.btnLoadGreetings.Location = new System.Drawing.Point(224, 155);
+            this.btnLoadGreetings.Name = "btnLoadGreetings";
+            this.btnLoadGreetings.Size = new System.Drawing.Size(183, 23);
+            this.btnLoadGreetings.Style = MetroFramework.MetroColorStyle.Blue;
+            this.btnLoadGreetings.TabIndex = 24;
+            this.btnLoadGreetings.Text = "Cargar greetings.json";
+            this.btnLoadGreetings.Theme = MetroFramework.MetroThemeStyle.Dark;
+            this.btnLoadGreetings.UseSelectable = true;
             // 
             // ChatBOT
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(762, 450);
+            this.Controls.Add(this.btnLoadGreetings);
+            this.Controls.Add(this.btnLoadCategoryMessages);
+            this.Controls.Add(this.btnSendManual);
+            this.Controls.Add(this.txtManualMessage);
             this.Controls.Add(this.lblProxy);
             this.Controls.Add(this.toggleProxy);
             this.Controls.Add(this.btnLoadConfig);
@@ -239,6 +311,10 @@
         private MetroFramework.Controls.MetroButton btnLoadConfig;
         private MetroFramework.Controls.MetroToggle toggleProxy;
         private MetroFramework.Controls.MetroLabel lblProxy;
+        private MetroFramework.Controls.MetroTextBox txtManualMessage;
+        private MetroFramework.Controls.MetroButton btnSendManual;
+        private MetroFramework.Controls.MetroButton btnLoadCategoryMessages;
+        private MetroFramework.Controls.MetroButton btnLoadGreetings;
     }
 }
 

--- a/Kick ChatBOT/Form1.cs
+++ b/Kick ChatBOT/Form1.cs
@@ -36,13 +36,21 @@ namespace Kick_ChatBOT
                 {
                     engine.ProxiesPath = saved.Proxies;
                 }
-                if (!string.IsNullOrEmpty(saved.Messages)) 
+                if (!string.IsNullOrEmpty(saved.Messages))
                 {
                     engine.MessagesPath = saved.Messages;
                 }
-                if (!string.IsNullOrEmpty(saved.Config)) 
+                if (!string.IsNullOrEmpty(saved.Config))
                 {
                     engine.ConfigPath = saved.Config;
+                }
+                if (!string.IsNullOrEmpty(saved.CategoryMessages))
+                {
+                    engine.CategoryMessagesPath = saved.CategoryMessages;
+                }
+                if (!string.IsNullOrEmpty(saved.Greetings))
+                {
+                    engine.GreetingsPath = saved.Greetings;
                 }
             }
             engine.LoadAll();
@@ -56,6 +64,9 @@ namespace Kick_ChatBOT
             btnLoadProxies.Click += (s, ev) => SelectAndLoadJson("proxies.json", path => engine.ProxiesPath = path, () => { engine.UseProxies = true; Log("proxies.json cargado"); });
             btnLoadMessages.Click += (s, ev) => SelectAndLoadJson("messages.json", path => engine.MessagesPath = path, () => Log("messages.json cargado"));
             btnLoadConfig.Click += (s, ev) => OpenConfigEditor();
+            btnLoadCategoryMessages.Click += (s, ev) => SelectAndLoadJson("category_messages.json", path => engine.CategoryMessagesPath = path, () => Log("category_messages.json cargado"));
+            btnLoadGreetings.Click += (s, ev) => SelectAndLoadJson("greetings.json", path => engine.GreetingsPath = path, () => Log("greetings.json cargado"));
+            btnSendManual.Click += async (s, ev) => await SendManualAsync();
 
             // toggle proxies
             toggleProxy.CheckedChanged += (s, ev) =>
@@ -95,6 +106,15 @@ namespace Kick_ChatBOT
             });
         }
 
+        private async Task SendManualAsync()
+        {
+            var channel = txtChannel.Text?.Trim();
+            var msg = txtManualMessage.Text?.Trim();
+            if (string.IsNullOrEmpty(channel) || string.IsNullOrEmpty(msg)) { Log("Canal y mensaje requeridos"); return; }
+            var err = await engine.SendManualMessageAsync(channel, msg, Log, CancellationToken.None);
+            if (!string.IsNullOrEmpty(err)) Log("Error: " + err);
+        }
+
         private void StopTasks()
         {
             try { cts?.Cancel(); } catch { }
@@ -131,6 +151,8 @@ namespace Kick_ChatBOT
                     else if (defaultName == "proxies.json") current.Proxies = dlg.FileName;
                     else if (defaultName == "messages.json") current.Messages = dlg.FileName;
                     else if (defaultName == "config.json") current.Config = dlg.FileName;
+                    else if (defaultName == "category_messages.json") current.CategoryMessages = dlg.FileName;
+                    else if (defaultName == "greetings.json") current.Greetings = dlg.FileName;
                     UserPreferences.SavePaths(current);
 
                     LogCounts();
@@ -149,6 +171,9 @@ namespace Kick_ChatBOT
             }
             var personalities = engine.Messages?.Personalities?.Count ?? 0;
             var emoteCats = engine.Messages?.KickEmotes?.Count ?? 0;
+            var categoryCount = engine.CategoryMessages?.Count ?? 0;
+            var greetingsCount = engine.Greetings?.Greetings?.Count ?? 0;
+            var farewellsCount = engine.Greetings?.Farewells?.Count ?? 0;
             
             Log($"=== ESTADO ACTUAL ===");
             
@@ -164,6 +189,8 @@ namespace Kick_ChatBOT
             Log($"📡 Proxies: {proxiesActive}/{proxiesTotal} activos");
             Log($"💬 Personalidades: {personalities}");
             Log($"🎭 Emotes: {emoteCats} categorías");
+            Log($"📚 Categorías: {categoryCount}");
+            Log($"👋 Saludos: {greetingsCount} | Despedidas: {farewellsCount}");
             
             if (accountsCount == 0)
             {

--- a/Kick ChatBOT/Kick ChatBOT.csproj
+++ b/Kick ChatBOT/Kick ChatBOT.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Models\Messages.cs" />
     <Compile Include="Models\ProxyConfig.cs" />
     <Compile Include="Models\UserPaths.cs" />
+    <Compile Include="Models\Greetings.cs" />
     <Compile Include="Services\JsonStorage.cs" />
     <Compile Include="Services\KickApiClient.cs" />
     <Compile Include="Services\IApiClient.cs" />

--- a/Kick ChatBOT/Models/Greetings.cs
+++ b/Kick ChatBOT/Models/Greetings.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Kick_ChatBOT.Models
+{
+    public class Greetings
+    {
+        [JsonProperty("greetings")] public List<string> Greetings { get; set; }
+        [JsonProperty("farewells")] public List<string> Farewells { get; set; }
+    }
+}

--- a/Kick ChatBOT/Models/UserPaths.cs
+++ b/Kick ChatBOT/Models/UserPaths.cs
@@ -8,6 +8,8 @@ namespace Kick_ChatBOT.Models
         [JsonProperty("proxies")] public string Proxies { get; set; }
         [JsonProperty("messages")] public string Messages { get; set; }
         [JsonProperty("config")] public string Config { get; set; }
+        [JsonProperty("category_messages")] public string CategoryMessages { get; set; }
+        [JsonProperty("greetings")] public string Greetings { get; set; }
     }
 }
 

--- a/Kick ChatBOT/Services/ChatbotEngine.cs
+++ b/Kick ChatBOT/Services/ChatbotEngine.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Kick_ChatBOT.Models;
+using Newtonsoft.Json.Linq;
 
 namespace Kick_ChatBOT.Services
 {
@@ -17,12 +18,17 @@ namespace Kick_ChatBOT.Services
         public List<Account> Accounts { get; private set; }
         public AppConfig Config { get; private set; }
         public Messages Messages { get; private set; }
+        public Dictionary<string, List<string>> CategoryMessages { get; private set; }
+        public Greetings Greetings { get; private set; }
         public ProxiesFile Proxies { get; private set; }
         public bool UseProxies { get; set; }
         public string KicksPath { get; set; }
         public string ConfigPath { get; set; }
         public string MessagesPath { get; set; }
         public string ProxiesPath { get; set; }
+        public string CategoryMessagesPath { get; set; }
+        public string GreetingsPath { get; set; }
+        public string CurrentCategory { get; private set; }
 
         public ChatbotEngine(string basePath)
         {
@@ -54,6 +60,8 @@ namespace Kick_ChatBOT.Services
             var configPath = GetPriorityPath(ConfigPath, "config.json");
             var messagesPath = GetPriorityPath(MessagesPath, "messages.json");
             var proxiesPath = GetPriorityPath(ProxiesPath, "proxies.json");
+            var categoryPath = GetPriorityPath(CategoryMessagesPath, "category_messages.json");
+            var greetingsPath = GetPriorityPath(GreetingsPath, "greetings.json");
 
             // Cargar cuentas: SOLO del archivo del usuario
             if (kicksPath != null)
@@ -83,6 +91,26 @@ namespace Kick_ChatBOT.Services
             else
             {
                 Messages = GetDefaultMessages();
+            }
+
+            // Cargar mensajes por categoría
+            if (categoryPath != null)
+            {
+                CategoryMessages = JsonStorage.ReadJsonFile(categoryPath, GetDefaultCategoryMessages());
+            }
+            else
+            {
+                CategoryMessages = GetDefaultCategoryMessages();
+            }
+
+            // Cargar saludos/despedidas
+            if (greetingsPath != null)
+            {
+                Greetings = JsonStorage.ReadJsonFile(greetingsPath, GetDefaultGreetings());
+            }
+            else
+            {
+                Greetings = GetDefaultGreetings();
             }
 
             // Cargar proxies
@@ -165,6 +193,43 @@ namespace Kick_ChatBOT.Services
                 {
                     { "greetings", new List<string> { "hey", "hi", "hello", "sup" } },
                     { "reactions", new List<string> { "nice", "cool", "wow", "gg" } }
+                }
+            };
+        }
+
+        private Dictionary<string, List<string>> GetDefaultCategoryMessages()
+        {
+            return new Dictionary<string, List<string>>
+            {
+                { "valorant", new List<string> { "qué buena ronda 🔥", "tremendo aim bro", "esa ulti fue dios" } },
+                { "just chatting", new List<string> { "jajaja qué historia", "¿y eso en qué acabó?", "esto parece una charla de café ☕" } },
+                { "default", new List<string> { "nice jugada", "buen movimiento ahí", "buena partida" } }
+            };
+        }
+
+        private Greetings GetDefaultGreetings()
+        {
+            return new Greetings
+            {
+                Greetings = new List<string>
+                {
+                    "holaaa, recién llego",
+                    "hola a todos",
+                    "buenas, me sumo",
+                    "hey, cómo va eso",
+                    "holi, entrando al chat",
+                    "qué tal gente",
+                    "saludos, listo para ver"
+                },
+                Farewells = new List<string>
+                {
+                    "chau",
+                    "nos vemos",
+                    "me voy yendo",
+                    "hasta luego",
+                    "adiós, cuídense",
+                    "me despido, bye",
+                    "nos leemos luego"
                 }
             };
         }
@@ -257,12 +322,23 @@ namespace Kick_ChatBOT.Services
                 return GetKickEmoteOnly();
             }
 
-            var personalities = Messages?.Personalities ?? new Dictionary<string, List<string>>();
-            List<string> list;
-            if (!personalities.TryGetValue(personality ?? "", out list))
+            List<string> list = null;
+
+            if (!string.IsNullOrEmpty(CurrentCategory) && CategoryMessages != null &&
+                CategoryMessages.TryGetValue(CurrentCategory, out var catList) && catList.Count > 0 &&
+                random.NextDouble() < 0.40)
             {
-                personalities.TryGetValue("casual", out list);
+                list = catList;
             }
+            else
+            {
+                var personalities = Messages?.Personalities ?? new Dictionary<string, List<string>>();
+                if (!personalities.TryGetValue(personality ?? "", out list))
+                {
+                    personalities.TryGetValue("casual", out list);
+                }
+            }
+
             if (list == null || list.Count == 0) list = new List<string> { "nice! 👍" };
             var baseMsg = list[random.Next(list.Count)];
 
@@ -305,6 +381,105 @@ namespace Kick_ChatBOT.Services
             return message;
         }
 
+        private string ExtractCategoryName(ChannelInfo info)
+        {
+            try
+            {
+                var name = info?.LiveStream?.Category?.Name ?? info?.LiveStream?.Category?.Slug;
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = info?.LiveStream?.Categories?.FirstOrDefault()?.Name ?? info?.LiveStream?.Categories?.FirstOrDefault()?.Slug;
+                }
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = info?.RecentCategories?.FirstOrDefault()?.Name ?? info?.RecentCategories?.FirstOrDefault()?.Slug;
+                }
+                return name?.ToLowerInvariant();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private async Task SendTemplateMessagesAsync(long chatroomId, List<string> templates, string action, Action<string> log, CancellationToken ct)
+        {
+            if (templates == null || templates.Count == 0 || Accounts == null || Accounts.Count == 0) return;
+            var accountsOrdered = Accounts.ToList();
+            if (Config.Behavior.RandomizeOrder) accountsOrdered = accountsOrdered.OrderBy(_ => random.Next()).ToList();
+            var count = random.Next(10, 16);
+            var idx = 0;
+            for (int i = 0; i < count; i++)
+            {
+                var acc = accountsOrdered[idx];
+                var msg = templates[random.Next(templates.Count)];
+                var typing = RandomBetweenDouble(Config.Delays.TypingSimulation.Min, Config.Delays.TypingSimulation.Max);
+                log($"👋 {acc.Username} {action} '{msg}'... ({typing:F1}s)");
+                await Task.Delay(TimeSpan.FromSeconds(typing), ct).ConfigureAwait(false);
+                IApiClient api = new KickApiClient(BuildProxyForAccount(acc));
+                try
+                {
+                    var result = await api.SendMessageAsync(chatroomId, msg, acc.Token, ct).ConfigureAwait(false);
+                    if (result.Item1)
+                    {
+                        acc.MessagesSent = (acc.MessagesSent) + 1;
+                        acc.LastMessageTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                        log($"✅ [{acc.Username}]: {msg}");
+                    }
+                    else
+                    {
+                        log($"❌ {acc.Username} FALLÓ al {action} - Status: {result.Item2}");
+                    }
+                }
+                finally
+                {
+                    api.Dispose();
+                }
+                idx = (idx + 1) % accountsOrdered.Count;
+                if (i < count - 1)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(random.Next(2, 5)), ct).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private Task SendGreetingMessagesAsync(long chatroomId, Action<string> log, CancellationToken ct)
+            => SendTemplateMessagesAsync(chatroomId, Greetings?.Greetings, "saludando", log, ct);
+
+        private Task SendFarewellMessagesAsync(long chatroomId, Action<string> log, CancellationToken ct)
+            => SendTemplateMessagesAsync(chatroomId, Greetings?.Farewells, "despidiéndose", log, ct);
+
+        public async Task<string> SendManualMessageAsync(string channel, string message, Action<string> log, CancellationToken ct)
+        {
+            if (Accounts == null || Accounts.Count == 0) return "No hay cuentas en kicks.json";
+            var acc = Accounts[0];
+            IApiClient api = new KickApiClient(BuildProxyForAccount(acc));
+            try
+            {
+                var info = await api.GetChannelInfoAsync(channel, acc.Token, ct).ConfigureAwait(false);
+                if (info.Item2 != null) return info.Item2;
+                var chatroomId = info.Item1?.ChatRoom?.Id ?? 0;
+                if (chatroomId <= 0) return "No se pudo obtener chatroom ID";
+                var result = await api.SendMessageAsync(chatroomId, message, acc.Token, ct).ConfigureAwait(false);
+                if (result.Item1)
+                {
+                    log($"✅ [{acc.Username}] (manual): {message}");
+                    acc.MessagesSent = (acc.MessagesSent) + 1;
+                    acc.LastMessageTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                }
+                else
+                {
+                    log($"❌ {acc.Username} FALLÓ al enviar manual - Status: {result.Item2}");
+                    log($"   📋 Respuesta: {result.Item3}");
+                }
+                return null;
+            }
+            finally
+            {
+                api.Dispose();
+            }
+        }
+
         public async Task<string> StartChatbotOnceBatchAsync(string channel, Action<string> log, CancellationToken ct)
         {
             if (Accounts == null || Accounts.Count == 0) return "No hay cuentas en kicks.json";
@@ -326,10 +501,13 @@ namespace Kick_ChatBOT.Services
                 if (info.Item2 != null) return info.Item2;
                 var chatroomId = info.Item1?.ChatRoom?.Id ?? 0;
                 if (chatroomId <= 0) return "No se pudo obtener chatroom ID";
-                
+                CurrentCategory = ExtractCategoryName(info.Item1);
                 log($"✅ Canal: {channel} (ID: {info.Item1.Id})");
                 log($"💬 Chatroom ID: {chatroomId}");
                 log($"🔴 En vivo: {(info.Item1.LiveStream != null ? "Sí" : "No")}");
+                if (!string.IsNullOrEmpty(CurrentCategory)) log($"🎮 Categoría: {CurrentCategory}");
+
+                await SendGreetingMessagesAsync(chatroomId, log, ct).ConfigureAwait(false);
 
                 var accountsOrdered = Accounts.ToList();
                 if (Config.Behavior.RandomizeOrder) accountsOrdered = accountsOrdered.OrderBy(_ => random.Next()).ToList();
@@ -352,6 +530,7 @@ namespace Kick_ChatBOT.Services
                         await Task.Delay(TimeSpan.FromSeconds(pause), ct).ConfigureAwait(false);
                     }
                 }
+                await SendFarewellMessagesAsync(chatroomId, log, CancellationToken.None).ConfigureAwait(false);
                 return null;
             }
             finally
@@ -462,6 +641,7 @@ namespace Kick_ChatBOT.Services
             if (Accounts == null || Accounts.Count == 0) return "No hay cuentas en kicks.json";
             var first = Accounts[0];
             IApiClient api = new KickApiClient(BuildProxyForAccount(first));
+            long chatroomId = 0;
             try
             {
                 var info = await api.GetChannelInfoAsync(channel, first.Token, ct).ConfigureAwait(false);
@@ -473,8 +653,16 @@ namespace Kick_ChatBOT.Services
                     info = await api.GetChannelInfoAsync(channel, first.Token, ct).ConfigureAwait(false);
                 }
                 if (info.Item2 != null) return info.Item2;
-                var chatroomId = info.Item1?.ChatRoom?.Id ?? 0;
+                chatroomId = info.Item1?.ChatRoom?.Id ?? 0;
                 if (chatroomId <= 0) return "No se pudo obtener chatroom ID";
+
+                CurrentCategory = ExtractCategoryName(info.Item1);
+                log($"✅ Canal: {channel} (ID: {info.Item1.Id})");
+                log($"💬 Chatroom ID: {chatroomId}");
+                log($"🔴 En vivo: {(info.Item1.LiveStream != null ? "Sí" : "No")}");
+                if (!string.IsNullOrEmpty(CurrentCategory)) log($"🎮 Categoría: {CurrentCategory}");
+
+                await SendGreetingMessagesAsync(chatroomId, log, ct).ConfigureAwait(false);
 
                 var accounts = Accounts.ToList();
                 if (Config.Behavior.RandomizeOrder) accounts = accounts.OrderBy(_ => random.Next()).ToList();
@@ -543,6 +731,7 @@ namespace Kick_ChatBOT.Services
             }
             finally
             {
+                await SendFarewellMessagesAsync(chatroomId, log, CancellationToken.None).ConfigureAwait(false);
                 api?.Dispose();
             }
         }

--- a/Kick ChatBOT/Services/KickApiClient.cs
+++ b/Kick ChatBOT/Services/KickApiClient.cs
@@ -291,12 +291,25 @@ namespace Kick_ChatBOT.Services
     {
         [JsonProperty("id")] public long Id { get; set; }
         [JsonProperty("chatroom")] public ChatRoom ChatRoom { get; set; }
-        [JsonProperty("livestream")] public object LiveStream { get; set; }
+        [JsonProperty("livestream")] public LiveStream LiveStream { get; set; }
+        [JsonProperty("recent_categories")] public List<Category> RecentCategories { get; set; }
     }
 
     public class ChatRoom
     {
         [JsonProperty("id")] public long Id { get; set; }
+    }
+
+    public class LiveStream
+    {
+        [JsonProperty("category")] public Category Category { get; set; }
+        [JsonProperty("categories")] public List<Category> Categories { get; set; }
+    }
+
+    public class Category
+    {
+        [JsonProperty("name")] public string Name { get; set; }
+        [JsonProperty("slug")] public string Slug { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary
- add manual message UI and load buttons for category and greeting files
- load and persist category-specific phrases and greeting templates
- extend engine with category detection, greeting/farewell messages, and manual send capability

## Testing
- `dotnet build "Kick ChatBOT.sln"` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2209390483219b8ac31c31eea83a